### PR TITLE
Set composer version to just major.minor.patch on git tag builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,12 @@ before_script:
 - docker run --rm --volume "$(pwd):/repo" $GITVERSION /repo -output json > GitVersion.json
 - cat GitVersion.json
 - export SEMVER=$(jq -r '.FullSemVer' GitVersion.json)
-- export PRE_RELEASE_LABEL=$(if [ $(jq '.PreReleaseLabel' GitVersion.json) != '""' ]; then echo '-dev'; fi)
-- export COMPOSER_VERSION="$(jq -r ".MajorMinorPatch" GitVersion.json)$PRE_RELEASE_LABEL$(jq -r ".CommitsSinceVersionSourcePadded" GitVersion.json)"
+- export MAJOR_MINOR_PATCH=$(jq -r ".MajorMinorPatch" GitVersion.json)
+- if [ -z "$TRAVIS_TAG" ]; then
+    export PRE_RELEASE_LABEL='-dev';
+    export COMMIT_COUNT=$(jq -r ".CommitsSinceVersionSourcePadded" GitVersion.json);
+  fi
+- export COMPOSER_VERSION="$MAJOR_MINOR_PATCH$PRE_RELEASE_LABEL$COMMIT_COUNT"
 - export ARCHIVE=${TRAVIS_REPO_SLUG#SwedbankPay/}-${SEMVER}.zip
 - echo $ARCHIVE
 - jq ".version=\"$COMPOSER_VERSION\"" composer.json > composer.version.json # Add "version" property to composer.version.json


### PR DESCRIPTION
Set composer version to just `major.minor.patch` on Git tag builds.