### PR TITLE
Checks if AfterCheckoutSubmitObserver is triggered by some other module

### DIFF
--- a/Observer/AfterCheckoutSubmitObserver.php
+++ b/Observer/AfterCheckoutSubmitObserver.php
@@ -17,6 +17,8 @@ use SwedbankPay\Core\Logger\Logger;
 use SwedbankPay\Checkout\Helper\Config as ConfigHelper;
 use SwedbankPay\Checkout\Helper\PaymentData;
 use SwedbankPay\Checkout\Model\Ui\ConfigProvider;
+use SwedbankPay\Checkout\Api\Data\OrderInterface as PaymentOrderInterface;
+
 
 class AfterCheckoutSubmitObserver implements ObserverInterface
 {
@@ -79,6 +81,10 @@ class AfterCheckoutSubmitObserver implements ObserverInterface
 
         /** @var OrderInterface $order */
         $order = $observer->getEvent()->getData('order');
+
+        if (!$order || !($this->paymentData->getByOrder($order) instanceof PaymentOrderInterface)) {
+            return;
+        }
 
         /** @var OrderPaymentInterface $payment */
         $payment = $order->getPayment();


### PR DESCRIPTION
Resolves an issue when other checkout modules (or Magento core multi-shipping checkout) are active and triggers AfterCheckoutSubmitObserver. So now it checks so that this observer is only triggered from the SwedbankPay module