### PR TITLE
Adds a support to load data from orders placed by any other checkout modules

### DIFF
--- a/Block/Adminhtml/Order/View/PaymentInfo.php
+++ b/Block/Adminhtml/Order/View/PaymentInfo.php
@@ -43,27 +43,41 @@ class PaymentInfo extends Template
 
     /**
      * @return array|null
-     * @throws Exception
-     * @throws ServiceException
-     * @throws NoSuchEntityException
      */
     public function getCurrentPayment()
     {
-        /** @var GetCurrentPayment $serviceRequest */
-        $serviceRequest = $this->service->init('Paymentorder', 'GetCurrentPayment');
+        if (!$this->getCurrentPaymentId()) {
+            return null;
+        }
+
+        try {
+            /** @var GetCurrentPayment $serviceRequest */
+            $serviceRequest = $this->service->init('Paymentorder', 'GetCurrentPayment');
+        } catch (ServiceException $e) {
+            return null;
+        }
+
         $serviceRequest->setRequestEndpoint('/psp/paymentorders/' . $this->getCurrentPaymentId() . '/currentpayment');
 
-        return $serviceRequest->send()->getResponseData();
+        try {
+            return $serviceRequest->send()->getResponseData();
+        } catch (Exception $e) {
+            return null;
+        }
     }
 
     /**
      * @return string
-     * @throws NoSuchEntityException
      */
     public function getCurrentPaymentId()
     {
         $orderId = $this->getRequest()->getParam('order_id');
-        $paymentOrderData = $this->paymentOrderRepo->getByOrderId($orderId);
+
+        try {
+            $paymentOrderData = $this->paymentOrderRepo->getByOrderId($orderId);
+        } catch (NoSuchEntityException $e) {
+            return null;
+        }
 
         return $paymentOrderData->getPaymentOrderId();
     }

--- a/Block/Adminhtml/Order/View/PaymentInfo.php
+++ b/Block/Adminhtml/Order/View/PaymentInfo.php
@@ -67,7 +67,7 @@ class PaymentInfo extends Template
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getCurrentPaymentId()
     {
@@ -80,5 +80,19 @@ class PaymentInfo extends Template
         }
 
         return $paymentOrderData->getPaymentOrderId();
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getCurrentPaymentInstrument()
+    {
+        $currentPayment = $this->getCurrentPayment();
+
+        if ($currentPayment && array_key_exists('menu_element_name', $currentPayment)) {
+            return $currentPayment['menu_element_name'];
+        }
+
+        return null;
     }
 }

--- a/view/adminhtml/templates/order/view/payment-info.phtml
+++ b/view/adminhtml/templates/order/view/payment-info.phtml
@@ -1,14 +1,14 @@
 <?php
 /** @var \SwedbankPay\Checkout\Block\Adminhtml\Order\View\PaymentInfo $this */
-
-/** @var array|null $currentPayment */
-$currentPayment = $this->getCurrentPayment();
 ?>
 
 <br />
-<?php if ($currentPayment): ?>
 <p>
-    <strong>SwedbankPay Payment Order ID:</strong> <?php echo $this->getCurrentPaymentId(); ?><br />
-    <strong>SwedbankPay Payment Instrument:</strong> <?php echo $currentPayment['menu_element_name']; ?>
+    <?php if ($this->getCurrentPaymentId()): ?>
+        <strong>SwedbankPay Payment Order ID:</strong> <?php echo $this->getCurrentPaymentId(); ?><br />
+    <?php endif; ?>
+
+    <?php if ($this->getCurrentPaymentInstrument()): ?>
+        <strong>SwedbankPay Payment Instrument:</strong> <?php echo $this->getCurrentPaymentInstrument(); ?>
+    <?php endif; ?>
 </p>
-<?php endif; ?>

--- a/view/adminhtml/templates/order/view/payment-info.phtml
+++ b/view/adminhtml/templates/order/view/payment-info.phtml
@@ -1,9 +1,14 @@
 <?php
 /** @var \SwedbankPay\Checkout\Block\Adminhtml\Order\View\PaymentInfo $this */
+
+/** @var array|null $currentPayment */
+$currentPayment = $this->getCurrentPayment();
 ?>
 
 <br />
+<?php if ($currentPayment): ?>
 <p>
     <strong>SwedbankPay Payment Order ID:</strong> <?php echo $this->getCurrentPaymentId(); ?><br />
-    <strong>SwedbankPay Payment Instrument:</strong> <?php echo $this->getCurrentPayment()['menu_element_name']; ?>
+    <strong>SwedbankPay Payment Instrument:</strong> <?php echo $currentPayment['menu_element_name']; ?>
 </p>
+<?php endif; ?>


### PR DESCRIPTION
Right now, it breaks at the Magento Order details page if the order is not placed by Swedbank Pay Checkout module. This PR adds the functionality to load data from orders placed by any other checkout modules.