### PR TITLE
Removes 'Proceed as guest' button & makes necessary changes

### DIFF
--- a/Block/Widget/CheckinWidget.php
+++ b/Block/Widget/CheckinWidget.php
@@ -11,7 +11,6 @@ use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\View\Element\Template;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Widget\Block\BlockInterface;
-use SwedbankPay\Api\Service\Consumer\Resource\ConsumerNationalIdentifier;
 use SwedbankPay\Api\Service\Consumer\Resource\Request\InitiateConsumerSession as ConsumerSessionResource;
 use SwedbankPay\Api\Service\Data\RequestInterface;
 use SwedbankPay\Api\Service\Data\ResponseInterface;
@@ -19,8 +18,8 @@ use SwedbankPay\Api\Service\Resource\Data\ResponseInterface as ResponseResourceI
 use SwedbankPay\Checkout\Helper\Config;
 use SwedbankPay\Checkout\Model\ConsumerSession as SwedbankPayConsumerSession;
 use SwedbankPay\Core\Exception\ServiceException;
-use SwedbankPay\Core\Model\Service;
 use SwedbankPay\Core\Logger\Logger;
+use SwedbankPay\Core\Model\Service;
 
 /**
  * @SuppressWarnings(PHPMD.CamelCaseMethodName)
@@ -161,29 +160,6 @@ class CheckinWidget extends Template implements BlockInterface
 
         $consumerSessionData = new ConsumerSessionResource();
         $consumerSessionData->setConsumerCountryCode($this->getDefaultCountry());
-
-        if ($this->customerSession->isLoggedIn()) {
-            $customerId = $this->customerSession->getCustomerId();
-            $customer = $this->customerRepository->getById($customerId);
-            $email = $customer->getEmail();
-            try {
-                $billingAddress = $this->addressRepository->getById($customer->getDefaultBilling());
-            } catch (LocalizedException $e) {
-                $this->logger->error($e->getMessage());
-                return false;
-            }
-            $msisdn = $billingAddress->getTelephone();
-            $countryCode = $billingAddress->getCountryId();
-            $this->eventManager->dispatch('swedbank_pay_checkout_before_initiate_consumer_session');
-
-            $nationalIdentifierData = new ConsumerNationalIdentifier();
-            $nationalIdentifierData->setCountryCode($countryCode);
-
-            $consumerSessionData->setMsisdn($msisdn)
-                ->setEmail($email)
-                ->setConsumerCountryCode($countryCode)
-                ->setNationalIdentifier($nationalIdentifierData);
-        }
 
         /** @var ResponseInterface|false $response */
         try {

--- a/view/frontend/web/js/action/shipping-methods-view.js
+++ b/view/frontend/web/js/action/shipping-methods-view.js
@@ -1,0 +1,13 @@
+define([
+    'jquery',
+    'ko',
+], function ($, _) {
+    'use strict';
+
+    return {
+        show: function(){
+            // Function needs to be hooked into
+            // In order to display the list of shipping methods
+        }
+    }
+});

--- a/view/frontend/web/js/view/checkin.js
+++ b/view/frontend/web/js/view/checkin.js
@@ -12,10 +12,11 @@ define([
     'Magento_Checkout/js/action/set-shipping-information',
     'SwedbankPay_Checkout/js/action/open-shipping-information',
     'SwedbankPay_Checkout/js/action/trigger-shipping-information-validation',
+    'SwedbankPay_Checkout/js/action/shipping-methods-view',
     'Magento_Checkout/js/model/address-converter',
     'Magento_Checkout/js/checkout-data',
     'mage/cookies'
-], function (Component, $, ko, _, $t, storage, stepNavigator, quote, registry, newCustomerAddress, setShippingInformationAction, openShippingInformation, triggerShippingInformationValidation, addressConverter, checkoutData) {
+], function (Component, $, ko, _, $t, storage, stepNavigator, quote, registry, newCustomerAddress, setShippingInformationAction, openShippingInformation, triggerShippingInformationValidation, shippingMethodsView, addressConverter, checkoutData) {
     'use strict';
 
     var SwedbankPay = window.swedbankPay,
@@ -144,6 +145,7 @@ define([
                 JSON.stringify(data),
                 true
             ).done(function(response){
+                shippingMethodsView.show();
                 onConsumerIdentifiedDelay(true);
                 self.isCheckedIn(true);
             }).fail(function(message){

--- a/view/frontend/web/template/checkin.html
+++ b/view/frontend/web/template/checkin.html
@@ -7,13 +7,11 @@
             <!-- ko if: !isCheckedIn() -->
                 <!-- ko if: !isRequired() -->
                     <!-- ko if: !isShippingSectionVisible() -->
-                            <button class="swedbank-pay-checkin__skip button" data-bind="i18n: 'Proceed as guest', click: proceedAsGuest"></button>
                     <!-- /ko -->
                 <!-- /ko -->
             <!-- /ko -->
 
             <!-- ko if: isCheckedIn() && !isShippingSectionVisible() -->
-                <button class="swedbank-pay-checkin__skip button" data-bind="i18n: 'Change shipping information', click: proceedAsGuest"></button>
             <!-- /ko -->
         </div>
     </div>

--- a/view/frontend/web/template/shipping.html
+++ b/view/frontend/web/template/shipping.html
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 -->
-<li id="shipping" class="checkout-shipping-address" data-bind="fadeVisible: visible()">
+<li id="shipping" class="checkout-shipping-address no-display">
     <div class="step-title" translate="'Shipping Address'" data-role="title" />
     <div id="checkout-step-shipping"
          class="step-content"


### PR DESCRIPTION
- [FEATURE] Removes Magento customer data when initiating consumer session
- [FEATURE] Removes 'Proceed as guest' button & hides default shipping fields
- [FEATURE] Displays shipping methods only when checkin is done through the iframe